### PR TITLE
Add composers.php to the module require files.

### DIFF
--- a/src/Creolab/LaravelModules/Module.php
+++ b/src/Creolab/LaravelModules/Module.php
@@ -139,6 +139,10 @@ class Module extends \Illuminate\Support\ServiceProvider {
 			$filters = $this->path('filters.php');
 			if ($this->app['files']->exists($filters)) require $filters;
 
+			// Require module composers
+			$composers = $this->path('composers.php');
+			if ($this->app['files']->exists($composers)) require $composers;
+
 			// Require module routes
 			$routes = $this->path('routes.php');
 			if ($this->app['files']->exists($routes)) require $routes;


### PR DESCRIPTION
Just thought you might add a composer.php require since it is common for people to use composers in a seperate file. Props for including the observers and bindings and helpers already.

Cheers.
