### PR TITLE
Added loading of multiple providers

### DIFF
--- a/src/Creolab/LaravelModules/Module.php
+++ b/src/Creolab/LaravelModules/Module.php
@@ -154,9 +154,14 @@ class Module extends \Illuminate\Support\ServiceProvider {
 	 */
 	public function registerProvider()
 	{
-		if ($provider = $this->def('provider'))
+		if ($providers = $this->def('provider'))
 		{
-			$this->app->register($instance = new $provider($this->app));
+			// Register every provider
+			foreach ($providers as $provider)
+			{
+				$this->app->register($instance = new $provider($this->app));
+			}
+
 		}
 	}
 


### PR DESCRIPTION
It is now possible to add multiple providers

module.json needs to be formatted like this: 

```
    "provider": [
                "App\\Modules\\Yourmodule\\Repo\\RepoServiceProvider",
                "App\\Modules\\Yourmodule\\Service\\Form\\FormServiceProvider"
            ]
```
