### PR TITLE
Fixed bug with multiple paths in manifest and manual mode

### DIFF
--- a/src/Finder.php
+++ b/src/Finder.php
@@ -112,11 +112,11 @@ class Finder {
 							$this->modules[$name] = new Module($name, $directory, null, $this->app, $path);
 						}
 					}
-
-					// Save the manifest file
-					$this->saveManifest();
 				}
 			}
+
+			// Save the manifest file
+			$this->saveManifest();
 		}
 
 		return $this->modules;
@@ -128,29 +128,61 @@ class Finder {
 	 */
 	public function manual($config = null)
 	{
-		if ( ! $config) $modules = $this->app['config']->get('modules::modules');
-		else            $modules = $config;
-
-		if ($modules)
+		if (! is_null($config))
 		{
-			foreach ($modules as $key => $module)
+			$this->createInstances($config);
+		}
+
+		else
+		{
+			$moduleGroups = $this->app['config']->get('modules::modules');
+
+			if ($moduleGroups)
 			{
-				// Get name first
-				if     (is_string($module)) $name = $module;
-				elseif (is_array($module))  $name = $key;
-
-				// The path
-				$path = base_path($this->app['config']->get('modules::path') . '/' . $name);
-
-				// Then the definition
-				$definition = (is_array($module)) ? $module : array();
-
-				// Create instance
-				$this->modules[$name] = new Module($name, $path, $definition, $this->app);
+				foreach ($moduleGroups as $group => $modules)
+				{
+					$this->createInstances($modules, $group);
+				}
 			}
 		}
 
 		return $this->modules;
+	}
+
+	/**
+	 * Create module instances
+	 * @param array $modules
+	 * @param string|null $groupPath
+	 * @return array
+	 */
+	public function createInstances($modules, $groupPath = null)
+	{
+		foreach ($modules as $key => $module)
+		{
+			// Get name and defintion
+			if (is_string($module))
+			{
+				$name = $module;	
+				
+				$definition = array();
+			}
+
+			elseif (is_array($module))
+			{
+				$name = $key;
+
+				$definition = $module;
+			}  
+
+			// Get group. Manifest mode has group defined on the module.
+			$group = (! is_null($groupPath)) ? $groupPath : $module['group'];
+
+			// The path
+			$path = base_path($group . '/' . $name);
+
+			// Create instance
+			$this->modules[$name] = new Module($name, $path, $definition, $this->app, $group);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Hi, I was going to use multiple paths but it didn't work as I expected. The "manual()" method in Finder doesn't take multiple paths into account. I guess this is a bug? Here's a possible fix.

First let's look at the "manual" mode. The purpose of this mode is optimization and to avoid scanning for directories. For this to work with multiple paths I chose to add the path to the modules array in the configuration like this:

```
'modules' => array(
    'app/modules' => array(
        'system' => array('enabled' => true),
    ),
    'another/modules/path' => array(
        'pages' => array('enabled' => false),
        'seo'   => array('enabled' => true),
    ),
),
```

Then there's the "manifest" mode. I moved the part that instantiates the modules into its own function. The manual function can then properly handle the new configuration options for modules as well as the the manifest mode.

Tested all three modes with both multiple and single module paths.

Cheers! 
