### PR TITLE
seeds directory added to Modules create command, Generate seeds

### DIFF
--- a/src/Commands/ModulesCreateCommand.php
+++ b/src/Commands/ModulesCreateCommand.php
@@ -66,6 +66,7 @@ class ModulesCreateCommand extends AbstractCommand {
 			$this->app['files']->makeDirectory($modulePath . '/models', 0755);
 			$this->app['files']->makeDirectory($modulePath . '/migrations', 0755);
 			$this->app['files']->makeDirectory($modulePath . '/views', 0755);
+			$this->app['files']->makeDirectory($modulePath . '/seeds', 0755);
 
 			// Autoload classes
 			$this->dumpAutoload();

--- a/src/Commands/ModulesGenerateCommand.php
+++ b/src/Commands/ModulesGenerateCommand.php
@@ -63,6 +63,13 @@ class ModulesGenerateCommand extends AbstractCommand {
 			$dirPath = $modulePath . '/views';
 			$this->call('generate:view', array('viewName' => $resource, '--path' => $dirPath));
 		}
+
+		// Generate a seed
+		if ($type == 'seed')
+		{
+			$dirPath = $modulePath . '/seeds';
+			$this->call('generate:seed', array('tableName' => $resource, '--path' => $dirPath));
+		}
 	}
 
 	/**


### PR DESCRIPTION
seeds directory added to Modules create command, Generate seeds with generate command give table name as resource for which you want to create seed, but here need to do some two lines manually one in module.json and one in created seed file

```
modules.json
"seeder": "App\\Modules\\Module_Name\\Seeds\\ResourceTableSeeder" 
```

```
ResourceTableSeeder.php
namespace App\Modules\Module_Name\Seeds;
```

after adding these lines run **composer dump-autoload**

now you can run **modules:seed** command to seed your database.
