### PR TITLE
Implementing support for service provider bootstrapping.

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -178,6 +178,9 @@ class Module extends \Illuminate\Support\ServiceProvider {
 			
 			// Log it
 			$this->app['modules']->logDebug('Module "' . $this->name . '" has been registered.');
+
+            // Allow service providers to bootstrap anything necessary after registered.
+            $this->bootstrapProviders();
 		}
 	}
 
@@ -204,6 +207,39 @@ class Module extends \Illuminate\Support\ServiceProvider {
 			}
 		}
 	}
+
+	/**
+	 * Bootstrap service provider for module
+	 * @return void
+	 */
+	public function bootstrapProviders()
+	{
+		$providers = $this->def('provider');
+
+		if ($providers)
+		{
+			if (is_array($providers))
+			{
+				foreach ($providers as $provider)
+				{
+                    $instance = $this->app->getRegistered($provider);
+                    if (method_exists($instance, 'bootstrap'))
+                    {
+                        $instance->bootstrap();
+                    }
+				}
+			}
+			else
+			{
+                $instance = $this->app->getRegistered($provider);
+                if (method_exists($instance, 'bootstrap'))
+                {
+                    $instance->bootstrap();
+                }
+			}
+		}
+	}
+
 
 	/**
 	 * Run the seeder if it exists

--- a/src/Module.php
+++ b/src/Module.php
@@ -231,7 +231,7 @@ class Module extends \Illuminate\Support\ServiceProvider {
 			}
 			else
 			{
-                $instance = $this->app->getRegistered($provider);
+                $instance = $this->app->getRegistered($providers);
                 if (method_exists($instance, 'bootstrap'))
                 {
                     $instance->bootstrap();

--- a/src/Providers/ModuleServiceProvider.php
+++ b/src/Providers/ModuleServiceProvider.php
@@ -1,0 +1,15 @@
+<?php namespace Creolab\LaravelModules\Providers;
+
+use Illuminate\Support\ServiceProvider; 
+use ModuleServiceProviderInterface;
+
+abstract class ModuleServiceProvider extends ServiceProvider {
+
+    /**
+     * Bootstrap module service provider once registered with the app.
+     *
+     * @return void
+     */
+    abstract public function bootstrap();
+
+}

--- a/src/Providers/ModuleServiceProviderInterface.php
+++ b/src/Providers/ModuleServiceProviderInterface.php
@@ -1,0 +1,11 @@
+<?php namespace Creolab\LaravelModules\Providers;
+
+interface ModuleServiceProviderInterface {
+
+    /**
+     * Module service providers should have the ability to implement a bootstrap
+     * once their provider is registered to the application.
+     */
+    public function bootstrap();
+
+}


### PR DESCRIPTION
Signed-off-by: Ashley Meadows takingsides@gmail.com

The idea here is once a service provider is registered their necessary files are included.  It would then be nice to bootstrap module code.

For example: handling routes once `routes.php` has been loaded or listening to events after `events.php` is loaded etc.

**edit**

Last night I was quite tired, but this morning I figured that it would be nice to abstract the ServiceProvider with the bootstrap method (with an interface) for clarity.

This works really well - what are your thoughts?
