### PR TITLE
Replaced require with require_once

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -151,7 +151,7 @@ class Module extends \Illuminate\Support\ServiceProvider {
 			foreach ($include as $file)
 			{
 				$path = $this->path($file);
-				if ($this->app['files']->exists($path)) require $path;
+				if ($this->app['files']->exists($path)) require_once $path;
 			}
 			
 			// Register alias(es) into artisan


### PR DESCRIPTION
Replaced require with require_once
Prevents duplicate function definitions when running Unit Tests
