### PR TITLE
Added the functionality for a 'paths' variable in the global config.

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -154,6 +154,20 @@ class Module extends \Illuminate\Support\ServiceProvider {
 				if ($this->app['files']->exists($path)) require $path;
 			}
 			
+			// Get paths to include with glob()
+			$globalPaths = $this->app['config']->get('modules::paths');
+			
+			// Include all paths if they exist and represent a file
+                        foreach ($globalPaths as $path)
+                        {
+                                $path = $this->path($path);
+                                $files = glob($path);
+                                foreach($files as $file)
+                                {
+                                        if (is_file($file)&&file_exists($file)) require $file;
+                                }
+                        }
+
 			// Register alias(es) into artisan
 			if(!is_null($this->def('alias'))) {
 				$aliases = $this->def('alias');


### PR DESCRIPTION
All strings defined in this array will be included using the php [glob() function](http://php.net/manual/en/function.glob.php). Instead of defining every single file in the `include` variable, one can now simply add a directory through `paths`.

eg. `config.php`:

```
'paths' => array(
        'start/*.php',
),
```
